### PR TITLE
Correct typings for `photos` and `emails` elements

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,13 +24,11 @@ declare namespace PassportGoogleOauthToken {
       middleName?: string;
       familyName: string;
     };
-    photos: [{ value: string }];
-    emails: [
-      {
-        value: string;
-        verified: boolean;
-      }
-    ];
+    photos: ValueObject[];
+    emails: {
+      value: string;
+      verified: boolean;
+    }[];
     displayName: string;
 
     _raw: string;


### PR DESCRIPTION
The current notation indicates a tuple - but the correct typing is as an array.